### PR TITLE
Add a target origin restriction to the test page

### DIFF
--- a/cookie_access_test.html
+++ b/cookie_access_test.html
@@ -5,16 +5,20 @@
 </head>
 <body>
 <script>
-    // Try to set a cookie
-    var randVal = Math.random();
-    var randVal2 = 'test_' + Math.random();
-    document.cookie = randVal2+'='+randVal;
-
-    if (getCookie(randVal2) == randVal) {
-        window.parent.postMessage('cookies', "*");
-    } else {
-        window.parent.postMessage('no_cookies', "*");
-    }
+    // From: https://stackoverflow.com/a/3855394
+    var qs = (function(a) {
+        if (a == "") return {};
+        var b = {};
+        for (var i = 0; i < a.length; ++i)
+        {
+            var p=a[i].split('=', 2);
+            if (p.length == 1)
+                b[p[0]] = "";
+            else
+                b[p[0]] = decodeURIComponent(p[1].replace(/\+/g, " "));
+        }
+        return b;
+    })(window.location.search.substr(1).split('&'));
 
     function getCookie(cname) {
         var name = cname + "=";
@@ -32,6 +36,29 @@
         return "";
     }
 
+    // Allowed test origins
+    // * senglehardt.com is here temporarily until we move the
+    //   test suite on that domain to a Mozilla-owned domain
+    // * pocket.com and getpocket.com are here for the ETP user study
+    var testOrigins = [
+      'senglehardt.com',
+      'pocket.com',
+      'getpocket.com'
+    ];
+
+    // Try to set a cookie
+    var randVal = Math.random();
+    var randVal2 = 'test_' + Math.random();
+    document.cookie = randVal2+'='+randVal;
+
+    // Return result
+    if ('test_origin' in qs && testOrigins.includes(qs['test_origin'])) {
+      if (getCookie(randVal2) == randVal) {
+          window.parent.postMessage('cookies', qs['test_origin']);
+      } else {
+          window.parent.postMessage('no_cookies', qs['test_origin']);
+      }
+    }
 </script>
 </body>
 </html>

--- a/cookie_access_test.html
+++ b/cookie_access_test.html
@@ -39,11 +39,13 @@
     // Allowed test origins
     // * senglehardt.com is here temporarily until we move the
     //   test suite on that domain to a Mozilla-owned domain
-    // * pocket.com and getpocket.com are here for the ETP user study
+    // * several Pocket origins for the ETP user study
     var testOrigins = [
       'senglehardt.com',
       'pocket.com',
-      'getpocket.com'
+      'getpocket.com',
+      'featfront-67etp-study.web.readitlater.com',
+      'etpstudy.web.readitlater.com'
     ];
 
     // Try to set a cookie

--- a/cookie_access_test.html
+++ b/cookie_access_test.html
@@ -53,10 +53,11 @@
 
     // Return result
     if ('test_origin' in qs && testOrigins.includes(qs['test_origin'])) {
+      var testOrigin = 'https://' + qs['test_origin'];
       if (getCookie(randVal2) == randVal) {
-          window.parent.postMessage('cookies', qs['test_origin']);
+          window.parent.postMessage('cookies', testOrigin);
       } else {
-          window.parent.postMessage('no_cookies', qs['test_origin']);
+          window.parent.postMessage('no_cookies', testOrigin);
       }
     } else {
       console.log("Test origin not in allow list, or no test origin given.");

--- a/cookie_access_test.html
+++ b/cookie_access_test.html
@@ -58,6 +58,8 @@
       } else {
           window.parent.postMessage('no_cookies', qs['test_origin']);
       }
+    } else {
+      console.log("Test origin not in allow list, or no test origin given.");
     }
 </script>
 </body>

--- a/cookie_access_test.html
+++ b/cookie_access_test.html
@@ -5,21 +5,6 @@
 </head>
 <body>
 <script>
-    // From: https://stackoverflow.com/a/3855394
-    var qs = (function(a) {
-        if (a == "") return {};
-        var b = {};
-        for (var i = 0; i < a.length; ++i)
-        {
-            var p=a[i].split('=', 2);
-            if (p.length == 1)
-                b[p[0]] = "";
-            else
-                b[p[0]] = decodeURIComponent(p[1].replace(/\+/g, " "));
-        }
-        return b;
-    })(window.location.search.substr(1).split('&'));
-
     function getCookie(cname) {
         var name = cname + "=";
         var decodedCookie = decodeURIComponent(document.cookie);
@@ -54,8 +39,9 @@
     document.cookie = randVal2+'='+randVal;
 
     // Return result
-    if ('test_origin' in qs && testOrigins.includes(qs['test_origin'])) {
-      var testOrigin = 'https://' + qs['test_origin'];
+    const qs = new URLSearchParams(window.location.search);
+    if (qs.has('test_origin') && testOrigins.includes(qs.get('test_origin'))) {
+      var testOrigin = 'https://' + qs.get('test_origin');
       if (getCookie(randVal2) == randVal) {
           window.parent.postMessage('cookies', testOrigin);
       } else {


### PR DESCRIPTION
This PR ads a configurable target origin to the test page. This prevents any website from being able to embed and probe our test pages to figure out a user's ETP settings. For now, I've added three origins: my own (which is the home of our [test suite](https://senglehardt.com/test/trackingprotection/test_pages/)) and two pocket origins for the ETP experiments.