### PR TITLE
Enable Mozilla static pages to access the cookies

### DIFF
--- a/cookie_access_test.html
+++ b/cookie_access_test.html
@@ -30,7 +30,8 @@
       'pocket.com',
       'getpocket.com',
       'featfront-67etp-study.web.readitlater.com',
-      'etpstudy.web.readitlater.com'
+      'etpstudy.web.readitlater.com',
+      'mozilla.github.io'
     ];
 
     // Try to set a cookie


### PR DESCRIPTION
# About this PR
To create a single testing page for ETP in https://github.com/mozilla/tracking-test/pull/12, we need to give dummytracker cookie access to the static Mozilla sites created using GitHub.