### PR TITLE
Samesite compatibility

### DIFF
--- a/cookie_access_test.html
+++ b/cookie_access_test.html
@@ -37,7 +37,7 @@
     // Try to set a cookie
     var randVal = Math.random();
     var randVal2 = 'test_' + Math.random();
-    document.cookie = randVal2+'='+randVal;
+    document.cookie = randVal2+'='+randVal+'; SameSite=None; Secure';
 
     // Return result
     const qs = new URLSearchParams(window.location.search);

--- a/set_cookie.html
+++ b/set_cookie.html
@@ -11,7 +11,7 @@
         var randVal = Math.random();
         var set = document.getElementById('cookie_set');
         set.innerHTML = randVal;
-        document.cookie = 'testPageCookie='+randVal;
+        document.cookie = 'testPageCookie='+randVal+'; SameSite=None; Secure';
 
         // Get a cookie
         var get = document.getElementById('cookie_read');


### PR DESCRIPTION
Our test pages are currently broken in Nightly since we have the `SameSite=lax` by default policy enabled (see [Bug 1625210](https://bugzilla.mozilla.org/show_bug.cgi?id=1625210)). This update adds `SameSite=None` and `Secure` to set cookies so they'll continue to work cross-origin.